### PR TITLE
Readme @aws-amplify -> @aws-amplify/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can also manually set up your resources if you would like. If you would like
 1. Install & configure the Amplify CLI
 
 ```sh
-npm install -g @aws-amplify
+npm install -g @aws-amplify/cli
 
 amplify configure
 ```


### PR DESCRIPTION
the ` npm install -g @aws-amplify` errors from the "Building the App (manually)" part errors, it should be `npm install -g @aws-amplify/cli`